### PR TITLE
Rename plsvote to pls.vote

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 <h1 align="center">
-    plsvote
+    pls.vote
 </h1>
 
 a project by [@lucasjohnston](https://www.twitter.com/lucasjohnston)

--- a/countries/gb.md
+++ b/countries/gb.md
@@ -11,7 +11,7 @@ registration:
     est_time: "5 minutes"
 reminder:
     email_address: "1week@followupthen.com"
-    email_body: "Hey!%0A%0AThis is a reminder sent from plsvote, reminding you to register to vote.%0AIt'll take you around 5 minutes, and gives you the chance to make sure your voice is heard 💪%0A%0AYou can sign up here: https://pls.vote/gb%0A%0ALots of love,%0Aplsvote%0A❤️%0A%0A"
+    email_body: "Hey!%0A%0AThis is a reminder sent from pls.vote, reminding you to register to vote.%0AIt'll take you around 5 minutes, and gives you the chance to make sure your voice is heard 💪%0A%0AYou can sign up here: https://pls.vote/gb%0A%0ALots of love,%0Aplsvote%0A❤️%0A%0A"
 qualifiers:
     - "a UK Citizen"
     - "a qualifying Commonwealth citizen resident living in the UK"

--- a/countries/us.md
+++ b/countries/us.md
@@ -11,7 +11,7 @@ registration:
     est_time: "5+ minutes, depending on your state,"
 reminder:
     email_address: "1week@followupthen.com"
-    email_body: "Hey!%0A%0AThis is a reminder sent from plsvote, reminding you to register to vote.%0AIt'll take you around 5 minutes, and gives you the chance to make sure your voice is heard 💪%0A%0AYou can sign up here: https://pls.vote/us%0A%0ALots of love,%0Aplsvote%0A❤️%0A%0A"
+    email_body: "Hey!%0A%0AThis is a reminder sent from pls.vote, reminding you to register to vote.%0AIt'll take you around 5 minutes, and gives you the chance to make sure your voice is heard 💪%0A%0AYou can sign up here: https://pls.vote/us%0A%0ALots of love,%0Aplsvote%0A❤️%0A%0A"
 qualifiers:
     - "a US Citizen"
     - "meeting your state's residency requirements"

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,7 +2,7 @@ const ReactGA = require('react-ga')
 
 ReactGA.initialize('UA-137041787-1')
 ReactGA.set({
-  appName: 'plsvote'
+  appName: 'pls.vote'
 })
 
 exports.onRouteUpdate = (state) => {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: 'plsvote',
+    title: 'pls.vote',
   },
   plugins: [
     `gatsby-plugin-styled-components`,
@@ -28,8 +28,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: 'plsvote',
-        short_name: 'plsvote',
+        name: 'pls.vote',
+        short_name: 'pls.vote',
         start_url: '/',
         background_color: '#DDD5D0',
         theme_color: '#272932',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "plsvote",
+  "name": "pls.vote",
   "private": false,
   "version": "1.0.0",
   "description": "Please vote!",
@@ -70,7 +70,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lucasjohnston/plsvote.git"
+    "url": "git+https://github.com/lucasjohnston/pls.vote.git"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/src/layouts/countries.js
+++ b/src/layouts/countries.js
@@ -57,7 +57,7 @@ class View extends React.Component<FrontmatterProps> {
               href={
                 'mailto:' +
                 reminder.email_address +
-                '?subject=🗳️ Reminder from plsvote&body=' +
+                '?subject=🗳️ Reminder from pls.vote&body=' +
                 reminder.email_body
               }
             >

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,9 +7,9 @@ export default class Index extends React.Component<*> {
   render() {
     return (
       <Layout>
-        <Title>plsvote</Title>
+        <Title>pls.vote</Title>
         <Subtitle>
-          Welcome to plsvote. We&#39;re working on our country selector - till then, how about going to our UK site?
+          Welcome to pls.vote. We&#39;re working on our country selector - till then, how about going to our UK site?
         </Subtitle>
         <ExternalLink nostyle href="/gb">
           <Button>Take me there</Button>

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -17,7 +17,7 @@ const LayoutComponent = (props: {
 }) => (
   <>
     <Helmet>
-      <title>plsvote</title>
+      <title>pls.vote</title>
       <meta charSet="utf-8" />
       <meta
         name="description"
@@ -25,7 +25,7 @@ const LayoutComponent = (props: {
       />
       <meta
         name="keywords"
-        content="register to vote, register to vote in election, voting registration, sign up to vote, sign up, register, registration, register to vote worldwide, living aboard, register to vote abroad, election, general election, primaries, voting, vote, plsvote, pls, vote, voting simple, click to vote, one click voting, lucas, johnston, lucas johnston, monzo, monzo bank, google, imperial, imperial college, starling, starling bank, software engineer, product manager, youngest engineer, youngest software engineer, 17 years old, 18 years old, 17 year old, 18 year old, programmer, young programmer, youngest programmer"
+        content="register to vote, register to vote in election, voting registration, sign up to vote, sign up, register, registration, register to vote worldwide, living aboard, register to vote abroad, election, general election, primaries, voting, vote, pls.vote, pls, vote, voting simple, click to vote, one click voting, lucas, johnston, lucas johnston, monzo, monzo bank, google, imperial, imperial college, starling, starling bank, software engineer, product manager, youngest engineer, youngest software engineer, 17 years old, 18 years old, 17 year old, 18 year old, programmer, young programmer, youngest programmer"
       />
       <meta name="robots" content="index, follow" />
       <meta
@@ -62,7 +62,7 @@ const LayoutComponent = (props: {
     <>
       <div className={props.className}>
         <Link nostyle to="/">
-          <Title small>🗳️ plsvote</Title>
+          <Title small>🗳️ pls.vote</Title>
         </Link>
         <Page>{props.children}</Page>
         <Footer>
@@ -73,7 +73,7 @@ const LayoutComponent = (props: {
             <Copy active>
               This site costs £80/year to run
               <br />
-              Buy me a coffee to help plsvote going! ☕
+              Buy me a coffee to help pls.vote going! ☕
             </Copy>
           </ExternalLink>
         </Footer>


### PR DESCRIPTION
This PR simply renames the `plsvote` package and brand to `pls.vote`, in line with the github repo name change.